### PR TITLE
Force authentication scheme to none so a default scheme can be applied.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,7 @@ module.exports = function statusPlugin(server, options, next) {
       const response = reply().code(204);
       return Promise.resolve(response);
     },
+    config: { auth: false },
   });
 
   return next();


### PR DESCRIPTION
I feel like it's good practice to set a default authentication scheme on an entire API.  When I did that, though, the health status endpoint also required authentication, which doesn't make sense.  

This small code change fixes that problem.  Seeking feedback and comments.  Is this safe to apply everywhere?